### PR TITLE
fix(requirements): 🔧 update 'PSScriptAnalyzer' version to 1.24.0

### DIFF
--- a/requirements.psd1
+++ b/requirements.psd1
@@ -21,7 +21,7 @@
         Version = '0.6.1'
     }
     'PSScriptAnalyzer' = @{
-        Version = '1.19.1'
+        Version = '1.24.0'
     }
     'PwshSpectreConsole' = @{
         Version = '2.3.0'


### PR DESCRIPTION
* Updated the version of 'PSScriptAnalyzer' from `1.19.1` to `1.24.0` to ensure compatibility and access to the latest features and fixes.
